### PR TITLE
Adjust variable type

### DIFF
--- a/secretpad-manager/src/main/java/org/secretflow/secretpad/manager/integration/datasource/oss/OssAutoCloseableClient.java
+++ b/secretpad-manager/src/main/java/org/secretflow/secretpad/manager/integration/datasource/oss/OssAutoCloseableClient.java
@@ -31,11 +31,11 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
  */
 public final class OssAutoCloseableClient implements AutoCloseable {
 
-    private static ClientConfiguration
+    private static final ClientConfiguration
             clientConfiguration = new ClientConfiguration().withConnectionTimeout(500)
             .withProtocol(Protocol.HTTP)
             .withSocketTimeout(500);
-    private AmazonS3 amazonS3Client;
+    private final AmazonS3 amazonS3Client;
 
     private OssAutoCloseableClient(AmazonS3 amazonS3Client) {
         this.amazonS3Client = amazonS3Client;

--- a/secretpad-persistence/src/main/java/org/secretflow/secretpad/persistence/datasync/producer/p2p/P2pPaddingNodeServiceImpl.java
+++ b/secretpad-persistence/src/main/java/org/secretflow/secretpad/persistence/datasync/producer/p2p/P2pPaddingNodeServiceImpl.java
@@ -57,7 +57,7 @@ public class P2pPaddingNodeServiceImpl implements PaddingNodeService {
 
     private final NodeRepository nodeRepository;
 
-    private Map<String, String> inst_Node = new ConcurrentHashMap<>();
+    private final Map<String, String> inst_Node = new ConcurrentHashMap<>();
 
     @Override
     public void paddingNodes(EntityChangeListener.DbChangeEvent<BaseAggregationRoot> event) {

--- a/secretpad-service/src/main/java/org/secretflow/secretpad/service/graph/GraphBuilder.java
+++ b/secretpad-service/src/main/java/org/secretflow/secretpad/service/graph/GraphBuilder.java
@@ -40,7 +40,6 @@ public class GraphBuilder {
     private final Map<String, List<String>> dependencies = new HashMap<>();
     private final Map<String, String> output2node = new HashMap<>();
     private final Map<String, String> input2node = new HashMap<>();
-    private final Map<String, List<String>> node2inputs = new HashMap<>();
     private final Map<String, GraphNodeInfo> nodeMap = new HashMap<>();
 
     /**
@@ -49,6 +48,7 @@ public class GraphBuilder {
      * @param nodes graph node information list
      */
     public GraphBuilder(List<GraphNodeInfo> nodes) {
+        Map<String, List<String>> node2inputs = new HashMap<>();
         if (!CollectionUtils.isEmpty(nodes)) {
             for (GraphNodeInfo node : nodes) {
                 String nodeId = node.getGraphNodeId();

--- a/secretpad-service/src/main/java/org/secretflow/secretpad/service/handler/datasource/HttpDatasourceHandler.java
+++ b/secretpad-service/src/main/java/org/secretflow/secretpad/service/handler/datasource/HttpDatasourceHandler.java
@@ -48,10 +48,10 @@ public class HttpDatasourceHandler extends AbstractDatasourceHandler {
 
 
     @Resource
-    private InstService instService;
+    private final InstService instService;
 
     @Resource
-    private EnvService envService;
+    private final EnvService envService;
 
     @Override
 

--- a/secretpad-service/src/main/java/org/secretflow/secretpad/service/model/task/TaskConfigResult.java
+++ b/secretpad-service/src/main/java/org/secretflow/secretpad/service/model/task/TaskConfigResult.java
@@ -21,8 +21,8 @@ package org.secretflow.secretpad.service.model.task;
  * @date 2024/11/18
  */
 public class TaskConfigResult {
-    private String taskInputConfig;
-    private String appImage;
+    private final String taskInputConfig;
+    private final String appImage;
 
     // Constructor, getters and setters
     public TaskConfigResult(String taskInputConfig, String appImage) {

--- a/secretpad-service/src/main/java/org/secretflow/secretpad/service/util/HttpUtils.java
+++ b/secretpad-service/src/main/java/org/secretflow/secretpad/service/util/HttpUtils.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 public final class HttpUtils {
 
-    private static OkHttpClient client = new OkHttpClient.Builder()
+    private static final OkHttpClient client = new OkHttpClient.Builder()
             .followRedirects(false)
             .connectTimeout(100, TimeUnit.MILLISECONDS)
             .build();


### PR DESCRIPTION
1. GraphBuilder中的node2inputs定义为局部变量使用即可，方法执行结束立即回收，满足最小可见性原则的同时无需GC时随对象实例回收，减少对象长期持有的内存

2. 其余修改中通过Spring注入的不可变对象增加final修饰，防止后续维护时意外修改字段引用，保护对象完整性