### PR TITLE
 文件编码处理优化

### DIFF
--- a/secretpad-common/src/main/java/org/secretflow/secretpad/common/util/FileUtils.java
+++ b/secretpad-common/src/main/java/org/secretflow/secretpad/common/util/FileUtils.java
@@ -42,12 +42,12 @@ public class FileUtils {
     /**
      *
      **/
-    public final static String FILE_SEPARATOR = "/";
+    public static final String FILE_SEPARATOR = "/";
 
     /**
      * cert limit 10kb
      **/
-    public final static long CERT_FILE_MAX_SIZE = 1 * 10 * 1024;
+    public static final long CERT_FILE_MAX_SIZE = 10 * 1024;
 
     /**
      * Load file from the classpath resources or filesystem
@@ -87,7 +87,7 @@ public class FileUtils {
      * @throws IOException
      */
     public static String readFile2String(File file) throws IOException {
-        return FileCopyUtils.copyToString(new FileReader(file));
+        return Files.readString(file.toPath(), StandardCharsets.UTF_8);
     }
 
 


### PR DESCRIPTION
1. bugfix：原方案FileReader使用平台默认编码可能导致跨系统乱码，应始终显式指定UTF-8编码。
2. 使用Files.readString()更简洁且线程安全。
3. 常量修饰符顺序调整更符合Java语言规范（JLS）建议