### PR TITLE
统一Base64编码文件字符集格式以避免跨平台报错及乱码

### DIFF
--- a/secretpad-common/src/main/java/org/secretflow/secretpad/common/util/Base64Utils.java
+++ b/secretpad-common/src/main/java/org/secretflow/secretpad/common/util/Base64Utils.java
@@ -18,6 +18,7 @@ package org.secretflow.secretpad.common.util;
 
 import org.apache.commons.codec.binary.Base64;
 
+import java.nio.charset.StandardCharsets;
 
 /**
  * ApprovalController.
@@ -27,17 +28,22 @@ import org.apache.commons.codec.binary.Base64;
  */
 public final class Base64Utils {
 
+    private static final java.nio.charset.Charset BASE64_CHARSET = StandardCharsets.ISO_8859_1;
+
     private Base64Utils() {
     }
 
     public static byte[] decode(String base64) {
-        byte[] bytes = base64.getBytes();
-        return Base64.decodeBase64(bytes);
+        if (base64 == null) {
+            return null;
+        }
+        return Base64.decodeBase64(base64.getBytes(BASE64_CHARSET));
     }
 
     public static String encode(byte[] bytes) {
-        return new String(Base64.encodeBase64(bytes));
+        if (bytes == null) {
+            return null;
+        }
+        return new String(Base64.encodeBase64(bytes), BASE64_CHARSET);
     }
-
-
 }


### PR DESCRIPTION
显式指定ISO-8859-1字符集，确保Base64编解码在不同操作系统和语言环境下的一致性，避免因平台默认字符集（如windows及linux）差异导致的乱码或数据损坏问题