### PR TITLE
资源泄露风险BUG修复及实现优化

### DIFF
--- a/secretpad-common/src/main/java/org/secretflow/secretpad/common/errorcode/SystemErrorCode.java
+++ b/secretpad-common/src/main/java/org/secretflow/secretpad/common/errorcode/SystemErrorCode.java
@@ -69,6 +69,8 @@ public enum SystemErrorCode implements ErrorCode {
 
     REQUEST_FREQUENCY_ERROR(2020111012),
 
+    FILE_OPERATION_ERROR(2020111013)
+
     ;
 
     private final int code;


### PR DESCRIPTION
1. 原实现存在资源泄露风险，使用try-with-resources管理InputStream/OutputStream，100%避免资源泄漏
2. 空数据处理中，使用StandardCharsets.UTF_8，跨平台行为一致以避免中文等特殊字符乱码
3. 调整缓冲区大小，1kb -> 8kb，减少系统调用次数提升传输效率
4. 合理进行响应体设置，对正常数据和空数据均正确设置Content-Length
5. ​错误日志记录请求关键参数（nodeId, domainDataId）和完整堆栈
6. 优化异常处理，单独捕获IOException，区分IO错误和系统错误
7. 流结束判断改用!= -1严格判断EOF，参见[Returns the number of bytes actually read, or ​​-1​ if the end of the stream has been reached.](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/io/InputStream.html#read(byte%5B%5D))
